### PR TITLE
Handle nonexistent team IDs correctly

### DIFF
--- a/lib/interrupt_helper/pager_duty.rb
+++ b/lib/interrupt_helper/pager_duty.rb
@@ -5,6 +5,8 @@ require 'pager_duty/connection'
 module InterruptHelper
   module PagerDuty
     def pagerduty(token)
+      token = token.to_s
+      return nil if token.empty?
       @pagerduty_clients ||= Hash.new { |h, k|
         h[k] = ::PagerDuty::Connection.new(k)
       }


### PR DESCRIPTION
This is to address a RuntimeError coming out of PagerDuty::Connection
when it attempts to parse results from a response that is (correctly)
returning nothing useful without authentication.

In addition, the list_services and list_team_services methods both need
updates to correctly handly empty team IDs and responses for that.
list_team_services shouldn't have any response handling and
list_services should account for not finding a team ID.

This changes the output of `int team ls FOO` slightly -- searches in
a specific team will now print the team's name regardless of whether or
not a team was requested.

Fixes #5.